### PR TITLE
Overwrite mr-robot theme settings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/academic"]
 	path = themes/academic
-	url = git@github.com:gcushen/hugo-academic.git
+	url = https://github.com/gcushen/hugo-academic.git

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Netlify Status](https://api.netlify.com/api/v1/badges/3471170d-4752-4659-8bac-82639eb93d27/deploy-status)](https://app.netlify.com/sites/slopezz/deploys)
+
 # [slopezz.dev](https://slopezz.dev)
 
 Static site for slopezz.dev using:

--- a/content/project/slopezz.dev/index.md
+++ b/content/project/slopezz.dev/index.md
@@ -33,6 +33,7 @@ links:
 slides: ""
 ---
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/3471170d-4752-4659-8bac-82639eb93d27/deploy-status)](https://app.netlify.com/sites/slopezz/deploys)
 
 Static site for slopezz.dev using:
 

--- a/data/themes/mr_robot.toml
+++ b/data/themes/mr_robot.toml
@@ -1,0 +1,19 @@
+# Overwrites from https://github.com/gcushen/hugo-academic/blob/master/data/themes/mr_robot.toml --> updates light to true / updates background on home_section to white
+# Theme metadata
+name = "Mr Robot"
+
+# Is theme light or dark?
+light = true
+
+# Primary
+primary = "rgb(0, 136, 204)"
+
+# Menu
+menu_primary = "rgb(33, 37, 41)"
+menu_text = "rgb(0, 136, 204)"
+menu_text_active = "rgba(255,255,255,1)"
+menu_title = "rgb(153, 153, 153)"
+
+# Home sections
+home_section_odd = "rgb(255, 255, 255)"
+home_section_even = "rgb(247, 247, 247)"


### PR DESCRIPTION
By default mr-robot theme displays dark mode

It has been overwritten default mr-robot theme by:
- Default mode is light
- Default background colour is white (instead of black, as now default mode is light instead of dark)
- Update gitmodule to https (if not error on Netlify deploy)
- Add Netlify status badge to repository README and to slopezz.dev project description